### PR TITLE
Replaced path.exists with fs.exists

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -41,7 +41,7 @@ http.createServer(function(request, response) {
     }
     
     var filename = path.join(process.cwd(), uri);
-    path.exists(filename, function(exists) {
+    fs.exists(filename, function(exists) {
       if(!exists) {
         response.writeHead(404, {"Content-Type": "text/plain"});
         response.write("404 Not Found\n");


### PR DESCRIPTION
path.exists() has been replaced by fs.exists in newer version of Node.js, replacing it prevents from having an "path.exists is not a function" error